### PR TITLE
Fix for timezone issue in create/edit appointments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,13 @@ JWT_SECRET=change_this_jwt_secret_key_for_production_use_long_random_string
 FRONTEND_URL=http://localhost:8080
 MAX_FILE_SIZE=10MB
 
-# Frontend Configuration
+# API URL Configuration
 MEDIQUX_API_URL=http://localhost:3000/api
 
 # Port Configuration (customizable)
+# Port values should be same as MEDIQUX_API_URL and FRONTEND_URL
+# This variables allows to customise the ports on which docker 
+# services are exposed on your server.
 BACKEND_PORT=3000
 FRONTEND_PORT=8080
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,21 @@ POSTGRES_PASSWORD=your_secure_database_password
 JWT_SECRET=your_long_random_jwt_secret_key
 
 # API Configuration
-MEDIQUX_API_URL=http://your-server:3000/api
+# If you are using a reverse proxy this can be,
+# MEDIQUX_API_URL=https://sub.domain.tld/api 
+# FRONTEND_URL=https://domain.tld
+MEDIQUX_API_URL=http://your-server:3000/api 
 FRONTEND_URL=http://your-server:8080
 
+# Port Configuration (customizable)
+# Port values should be same as MEDIQUX_API_URL and FRONTEND_URL
+# This variables allows to customise the ports on which docker 
+# services are exposed on your server.
+BACKEND_PORT=3000       
+FRONTEND_PORT=8080
+
 # Optional: Adjust file upload limits
-MAX_FILE_SIZE=50MB
+MAX_FILE_SIZE=10MB
 
 # Optional: User/Group IDs (usually 1000 works)
 PUID=1000
@@ -132,7 +142,6 @@ docker compose -f docker-compose.dev.yml up -d
 ```bash
 # Security (IMPORTANT: Change these!)
 JWT_SECRET=your_very_long_random_secret_key_here
-SESSION_SECRET=your_session_secret_key_here
 POSTGRES_PASSWORD=your_secure_database_password
 
 # Network


### PR DESCRIPTION
Fixed timezone conversion issue in appointment scheduling - appointments now save and display in correct local time instead of showing UTC offset errors.