### PR TITLE
fix: apply patient filter to stats endpoints and restrict patient access by role

### DIFF
--- a/backend/src/routes/appointments.js
+++ b/backend/src/routes/appointments.js
@@ -4,10 +4,21 @@ const db = require('../database/db');
 const { addPatientFilter } = require('../middleware/auth');
 
 // Get upcoming appointments (for dashboard) - must be before /:id route
-router.get('/dashboard/upcoming', async (req, res) => {
+router.get('/dashboard/upcoming', addPatientFilter, async (req, res) => {
   try {
+    if (req.patientFilter === 'none') {
+      return res.json({ success: true, data: [] });
+    }
+
+    let whereClause = "WHERE a.appointment_date >= NOW() AND a.status = 'scheduled'";
+    const queryParams = [];
+    if (req.patientFilter) {
+      whereClause += ' AND a.patient_id = $1';
+      queryParams.push(req.patientFilter);
+    }
+
     const result = await db.query(`
-      SELECT 
+      SELECT
         a.id,
         a.appointment_date,
         a.type,
@@ -19,12 +30,11 @@ router.get('/dashboard/upcoming', async (req, res) => {
       FROM appointments a
       LEFT JOIN patients p ON a.patient_id = p.id
       LEFT JOIN doctors d ON a.doctor_id = d.id
-      WHERE a.appointment_date >= NOW() 
-        AND a.status = 'scheduled'
+      ${whereClause}
       ORDER BY a.appointment_date ASC
       LIMIT 5
-    `);
-    
+    `, queryParams);
+
     res.json({
       success: true,
       data: result.rows
@@ -39,18 +49,30 @@ router.get('/dashboard/upcoming', async (req, res) => {
 });
 
 // Get appointment statistics - must be before /:id route
-router.get('/stats/summary', async (req, res) => {
+router.get('/stats/summary', addPatientFilter, async (req, res) => {
   try {
+    if (req.patientFilter === 'none') {
+      return res.json({ success: true, data: { total_appointments: 0, upcoming: 0, completed: 0, cancelled: 0, today: 0 } });
+    }
+
+    let whereClause = '';
+    const queryParams = [];
+    if (req.patientFilter) {
+      whereClause = 'WHERE patient_id = $1';
+      queryParams.push(req.patientFilter);
+    }
+
     const result = await db.query(`
-      SELECT 
+      SELECT
         COUNT(*) as total_appointments,
         COUNT(CASE WHEN status = 'scheduled' AND appointment_date >= NOW() THEN 1 END) as upcoming,
         COUNT(CASE WHEN status = 'completed' THEN 1 END) as completed,
         COUNT(CASE WHEN status = 'cancelled' THEN 1 END) as cancelled,
         COUNT(CASE WHEN appointment_date::date = CURRENT_DATE THEN 1 END) as today
       FROM appointments
-    `);
-    
+      ${whereClause}
+    `, queryParams);
+
     res.json({
       success: true,
       data: result.rows[0]

--- a/backend/src/routes/patients.js
+++ b/backend/src/routes/patients.js
@@ -104,7 +104,7 @@ router.post('/', async (req, res) => {
     
     const result = await db.query(`
       INSERT INTO patients (
-        first_name, last_name, date_of_birth, gender, 
+        first_name, last_name, date_of_birth, gender,
         phone, email, address, emergency_contact_name, emergency_contact_phone
       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING *
@@ -112,10 +112,20 @@ router.post('/', async (req, res) => {
       first_name, last_name, date_of_birth, gender,
       phone, email, address, emergency_contact_name, emergency_contact_phone
     ]);
-    
+
+    const newPatient = result.rows[0];
+
+    // Auto-link the new patient to the user's account if they are non-admin and have no patient linked yet
+    if (req.user.role !== 'admin' && !req.user.patientId) {
+      await db.query(
+        'UPDATE users SET patient_id = $1 WHERE id = $2',
+        [newPatient.id, req.user.id]
+      );
+    }
+
     res.status(201).json({
       success: true,
-      data: result.rows[0],
+      data: newPatient,
       message: 'Patient created successfully'
     });
   } catch (error) {

--- a/backend/src/routes/prescriptions.js
+++ b/backend/src/routes/prescriptions.js
@@ -403,10 +403,21 @@ router.delete('/:id', async (req, res) => {
 });
 
 // Get prescription statistics
-router.get('/stats/summary', async (req, res) => {
+router.get('/stats/summary', addPatientFilter, async (req, res) => {
   try {
+    if (req.patientFilter === 'none') {
+      return res.json({ success: true, data: { total_prescriptions: 0, active_prescriptions: 0, unique_patients: 0, recent_prescriptions: 0 } });
+    }
+
+    let whereClause = '';
+    const queryParams = [];
+    if (req.patientFilter) {
+      whereClause = 'WHERE a.patient_id = $1';
+      queryParams.push(req.patientFilter);
+    }
+
     const result = await db.query(`
-      SELECT 
+      SELECT
         COUNT(*) as total_prescriptions,
         COUNT(CASE WHEN COALESCE(pm.status, 'active') = 'active' THEN 1 END) as active_prescriptions,
         COUNT(DISTINCT a.patient_id) as unique_patients,
@@ -414,8 +425,9 @@ router.get('/stats/summary', async (req, res) => {
       FROM prescriptions p
       LEFT JOIN appointments a ON p.appointment_id = a.id
       LEFT JOIN patient_medications pm ON (a.patient_id = pm.patient_id AND p.medication_id = pm.medication_id)
-    `);
-    
+      ${whereClause}
+    `, queryParams);
+
     res.json({
       success: true,
       data: result.rows[0]

--- a/backend/src/routes/test-results.js
+++ b/backend/src/routes/test-results.js
@@ -1575,18 +1575,30 @@ router.delete('/:id', authenticateToken, addPatientFilter, async (req, res) => {
 });
 
 // Get test result statistics
-router.get('/stats/summary', async (req, res) => {
+router.get('/stats/summary', addPatientFilter, async (req, res) => {
   try {
+    if (req.patientFilter === 'none') {
+      return res.json({ success: true, data: { total_reports: 0, unique_patients: 0, recent_reports: 0, abnormal_values: 0 } });
+    }
+
+    let whereClause = '';
+    const queryParams = [];
+    if (req.patientFilter) {
+      whereClause = 'WHERE tr.patient_id = $1';
+      queryParams.push(req.patientFilter);
+    }
+
     const result = await db.query(`
-      SELECT 
+      SELECT
         COUNT(DISTINCT tr.id) as total_reports,
         COUNT(DISTINCT tr.patient_id) as unique_patients,
         COUNT(CASE WHEN tr.created_at >= CURRENT_DATE - INTERVAL '30 days' THEN 1 END) as recent_reports,
         COUNT(CASE WHEN lv.status IN ('high', 'low', 'critical') THEN 1 END) as abnormal_values
       FROM test_results tr
       LEFT JOIN lab_values lv ON tr.id = lv.test_result_id
-    `);
-    
+      ${whereClause}
+    `, queryParams);
+
     res.json({
       success: true,
       data: result.rows[0]

--- a/frontend/patients.html
+++ b/frontend/patients.html
@@ -66,7 +66,7 @@
             <div class="col-12">
                 <div class="d-flex justify-content-between align-items-center mb-4">
                     <h1><i class="bi bi-people"></i> Patient Management</h1>
-                    <button class="btn btn-primary admin-action" data-bs-toggle="modal" data-bs-target="#patientModal" onclick="openAddPatientModal()">
+                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#patientModal" onclick="openAddPatientModal()">
                         <i class="bi bi-person-plus"></i> Add New Patient
                     </button>
                 </div>
@@ -136,7 +136,7 @@
                     <i class="bi bi-person-x display-1 text-muted"></i>
                     <h3 class="text-muted">No Patients Found</h3>
                     <p class="text-muted">Start by adding your first patient.</p>
-                    <button class="btn btn-primary admin-action" data-bs-toggle="modal" data-bs-target="#patientModal" onclick="openAddPatientModal()">
+                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#patientModal" onclick="openAddPatientModal()">
                         <i class="bi bi-person-plus"></i> Add Patient
                     </button>
                 </div>


### PR DESCRIPTION
- Apply addPatientFilter middleware to /stats/summary on appointments, prescriptions, and test-results routes so non-admin users only see
  their own data in dashboard stat cards
- Apply addPatientFilter to /appointments/dashboard/upcoming so the
  home page upcoming appointments card respects patient ownership
- Auto-link a newly created patient to the creating user when the user has no existing patient_id (enables non-admin users to see their own
  patient after creation)
- Remove admin-action CSS class from "Add Patient" buttons on patients.html so non-admin users can access the add patient flow