### PR TITLE
fix: high-severity reliability issues (S2871, S7059)

### DIFF
--- a/backend/src/routes/institutions.js
+++ b/backend/src/routes/institutions.js
@@ -257,7 +257,7 @@ router.get('/types/available', async (req, res) => {
     // Add common institution types
     const commonTypes = ['Hospital', 'Clinic', 'Laboratory', 'Pharmacy', 'Diagnostic Center', 'Nursing Home'];
     const existingTypes = result.rows.map(row => row.type);
-    const allTypes = [...new Set([...commonTypes, ...existingTypes])].sort();
+    const allTypes = [...new Set([...commonTypes, ...existingTypes])].sort((a, b) => a.localeCompare(b));
     
     res.json({
       success: true,

--- a/backend/src/routes/medications.js
+++ b/backend/src/routes/medications.js
@@ -362,7 +362,7 @@ router.get('/forms/available', async (req, res) => {
     ];
     
     const existingForms = result.rows.map(row => row.form);
-    const allForms = [...new Set([...commonForms, ...existingForms])].sort();
+    const allForms = [...new Set([...commonForms, ...existingForms])].sort((a, b) => a.localeCompare(b));
     
     res.json({
       success: true,

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -3,11 +3,13 @@ class AuthManager {
         this.baseURL = window.getApiBaseUrl();
         this.token = localStorage.getItem('authToken');
         this.user = JSON.parse(localStorage.getItem('user') || 'null');
-        
+
         this.validateAndClearTokens();
-        
+    }
+
+    async init() {
         if (window.location.pathname.includes('login.html')) {
-            this.initLoginPage();
+            await this.initLoginPage();
         } else {
             this.checkAuth();
         }
@@ -388,6 +390,7 @@ class AuthManager {
 
 document.addEventListener('DOMContentLoaded', () => {
     window.authManager = new AuthManager();
+    window.authManager.init();
 });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/frontend/js/doctors.js
+++ b/frontend/js/doctors.js
@@ -138,7 +138,7 @@ function populateSpecialtyFilter() {
     const specialties = [...new Set(allDoctors
         .map(doctor => doctor.specialty)
         .filter(specialty => specialty && specialty.trim())
-    )].sort();
+    )].sort((a, b) => a.localeCompare(b));
     
     const select = document.getElementById('specialtyFilter');
     select.innerHTML = '<option value="">All Specialties</option>' + 

--- a/frontend/js/institutions.js
+++ b/frontend/js/institutions.js
@@ -133,7 +133,7 @@ function populateTypeFilter() {
     const types = [...new Set(allInstitutions
         .map(institution => institution.type)
         .filter(type => type && type.trim())
-    )].sort();
+    )].sort((a, b) => a.localeCompare(b));
     
     const select = document.getElementById('typeFilter');
     select.innerHTML = '<option value="">All Types</option>' + 


### PR DESCRIPTION
- Provide explicit localeCompare compare functions for the remaining bare .sort() calls flagged by S2871 (medications forms, institution types, and their frontend filter dropdowns), matching the pattern already used for conditions.js.
- S7059: AuthManager kicked off an unawaited async operation (initLoginPage) from its constructor. Moved the login/auth-check branch into a separate init() method called right after construction, so the constructor stays synchronous.

Verified: full Jest suite (464 tests) green; live smoke test against the running develop deployment via Playwright covers logged-out redirect, login, protected-page auth state, and both fixed dropdowns rendering correctly sorted data.