### PR TITLE
docs: explain rationale for removing automatic lab value extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Mediqux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.13] - 2026-08-08
+## [1.0.13] - 2026-08-09
 
 ### 🐛 Bug Fixes
 
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔥 Removed
 
-- **Automatic lab value extraction removed** — Uploading a lab report PDF no longer attempts to parse or pattern-match values out of the document. PDFs are stored as-is; use **Manual Entry** to record lab values, or the **Lab Panels** reference-range feature to define reusable panels. This removes the `pdf-parse` dependency, the pattern-matching/confidence-scoring logic in `test-results.js`, and the "review extracted values" UI (part of which was already unreachable dead code). The `extracted_text`/`structured_data` columns on `test_results` are left in place (unused) — no migration needed.
+- **Automatic lab value extraction removed** — Uploading a lab report PDF no longer attempts to parse or pattern-match values out of the document. Lab report formats vary too much across labs and countries to generalize reliably with pattern matching, and in practice the extracted values still needed manual review and correction most of the time — so the automation added more overhead than it saved. PDFs are stored as-is; use **Manual Entry** to record lab values, or the **Lab Panels** reference-range feature to define reusable panels. This removes the `pdf-parse` dependency, the pattern-matching/confidence-scoring logic in `test-results.js`, and the "review extracted values" UI (part of which was already unreachable dead code). The `extracted_text`/`structured_data` columns on `test_results` are left in place (unused) — no migration needed.
 
 ## [1.0.12] - 2026-06-26
 


### PR DESCRIPTION
Lab report layouts vary too much across labs/countries to generalize with pattern matching, and the extracted values still needed manual review most of the time anyway - the automation cost more than it saved.