### PR TITLE
Resolve CodeQL alerts by removing unused variables and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Mediqux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🔧 Code Quality
+
+- **CodeQL cleanup** — resolved all 12 open CodeQL alerts (all low-severity reliability/cleanliness findings, no vulnerabilities): removed 7 dead `const form = document.getElementById(...)` declarations left over in `saveX()` functions across appointments, prescriptions, patients, medications, doctors, institutions, and conditions pages; removed an unused `newTab` variable capturing `window.open()`'s return value in lab-reports.js; removed a `let overallStatus` variable in lab-reports.js that was assigned but never read (the actually-used `statusBadge` variable was untouched); removed an unused `Logger` variable in `logger.test.js` while preserving its `jest.resetModules()` side effect; removed an unused `path` import in `server.js`.
+
 ## [1.0.13] - 2026-08-09
 
 ### 🐛 Bug Fixes

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const cors = require('cors');
-const path = require('path');
 require('dotenv').config({ quiet: true });
 
 const rateLimit = require('express-rate-limit');

--- a/backend/tests/utils/logger.test.js
+++ b/backend/tests/utils/logger.test.js
@@ -1,11 +1,9 @@
 // We test the real Logger class — not a mock
 // Spy on console methods to verify calls without polluting test output
 
-const Logger = (() => {
-  // Re-require so we get a fresh instance per test suite
-  jest.resetModules();
-  return require('../../src/utils/logger').constructor;
-})();
+// Reset the module registry so the singleton required below is a fresh
+// instance for this suite, not one left over from another test file
+jest.resetModules();
 
 // Re-import the singleton for tests that just need it working
 const logger = require('../../src/utils/logger');

--- a/frontend/js/appointments.js
+++ b/frontend/js/appointments.js
@@ -392,8 +392,6 @@ async function editAppointment(id) {
 }
 
 async function saveAppointment() {
-    const form = document.getElementById('appointmentForm');
-    
     clearAllFieldErrors();
     
     let hasErrors = false;

--- a/frontend/js/conditions.js
+++ b/frontend/js/conditions.js
@@ -308,8 +308,6 @@ async function editCondition(id) {
 
 // Save condition (create or update)
 async function saveCondition() {
-    const form = document.getElementById('conditionForm');
-    
     // Clear all previous validation states
     clearAllFieldErrors();
     

--- a/frontend/js/doctors.js
+++ b/frontend/js/doctors.js
@@ -310,8 +310,6 @@ async function editDoctor(id) {
 
 // Save doctor (create or update)
 async function saveDoctor() {
-    const form = document.getElementById('doctorForm');
-    
     // Clear all previous validation states
     clearAllFieldErrors();
     

--- a/frontend/js/institutions.js
+++ b/frontend/js/institutions.js
@@ -295,8 +295,6 @@ async function editInstitution(id) {
 
 // Save institution (create or update)
 async function saveInstitution() {
-    const form = document.getElementById('institutionForm');
-    
     // Clear all previous validation states
     clearAllFieldErrors();
     

--- a/frontend/js/lab-reports.js
+++ b/frontend/js/lab-reports.js
@@ -285,15 +285,13 @@ function displayReports() {
         }
         
         // Determine overall status
-        let overallStatus = 'normal';
         let statusBadge = '<span class="badge bg-success">Normal</span>';
-        
+
         if (report.lab_values) {
-            const abnormalValues = report.lab_values.filter(val => 
+            const abnormalValues = report.lab_values.filter(val =>
                 val.status && val.status.toLowerCase() !== 'normal'
             );
             if (abnormalValues.length > 0) {
-                overallStatus = 'abnormal';
                 statusBadge = `<span class="badge bg-warning">Abnormal (${abnormalValues.length})</span>`;
             }
         }
@@ -1029,7 +1027,7 @@ async function viewPDF(reportId) {
         
         // Create object URL and open in new tab
         const url = URL.createObjectURL(blob);
-        const newTab = window.open(url, '_blank');
+        window.open(url, '_blank');
         
         // Clean up the URL after a delay
         setTimeout(() => {

--- a/frontend/js/medications.js
+++ b/frontend/js/medications.js
@@ -554,8 +554,6 @@ async function editMedication(id) {
 
 // Save medication (create or update)
 async function saveMedication() {
-    const form = document.getElementById('medicationForm');
-    
     // Clear all previous validation states
     clearAllFieldErrors();
     

--- a/frontend/js/patients.js
+++ b/frontend/js/patients.js
@@ -258,8 +258,6 @@ window.editFromView = editFromView;
 
 // Save patient (create or update)
 async function savePatient() {
-    const form = document.getElementById('patientForm');
-    
     // Clear all previous validation states
     clearAllFieldErrors();
     

--- a/frontend/js/prescriptions.js
+++ b/frontend/js/prescriptions.js
@@ -339,8 +339,6 @@ function showFieldError(input, message) {
 
 // Save prescription (create or update)
 async function savePrescription() {
-    const form = document.getElementById('prescriptionForm');
-    
     // Clear all previous validation states
     clearAllFieldErrors();
     


### PR DESCRIPTION
All 12 open alerts were js/unused-local-variable (note) or js/useless-assignment-to-local (warning) - no security vulnerabilities in the open set (3 dismissed, 58 already fixed historically per CodeQL's own tracking).

- 7x dead `const form = document.getElementById(...)` in saveX() functions (appointments, prescriptions, patients, medications, doctors, institutions, conditions) - each confirmed genuinely unused via full-function grep before removal. The similarly-named `form` variable in each file's separate clearAllFieldErrors() function (which does use it) was left untouched.
- lab-reports.js: removed `newTab` capturing window.open()'s return value - the tab-opening side effect happens regardless of whether the return value is captured, so this is a pure no-op removal.
- lab-reports.js: removed `overallStatus`, which was assigned 'normal' then conditionally reassigned 'abnormal' but never read anywhere - only the separate `statusBadge` variable (left intact) is actually used in the rendered table row.
- logger.test.js: removed the unused `Logger` constructor capture, but kept the `jest.resetModules()` call it wrapped, since that reset is what gives the subsequent `require(...)` a fresh singleton instance - removing the whole IIFE would have silently dropped that isolation.
- server.js: removed the `path` import, confirmed no `path.*` usage anywhere in the file.