### PR TITLE
fix: add missing Lotion option to medication dosage forms dropdown

### DIFF
--- a/frontend/medications.html
+++ b/frontend/medications.html
@@ -242,6 +242,7 @@
                                             <option value="Cream">Cream</option>
                                             <option value="Ointment">Ointment</option>
                                             <option value="Gel">Gel</option>
+                                            <option value="Lotion">Lotion</option>
                                             <option value="Patch">Patch</option>
                                             <option value="Inhaler">Inhaler</option>
                                             <option value="Spray">Spray</option>


### PR DESCRIPTION
The backend's commonForms list (used for the filter dropdown) already included Lotion, but the create/edit modal's hardcoded <select> in medications.html never had it, so it couldn't actually be selected when adding or editing a medication despite the filter dropdown implying it was a supported option.

Verified live: Lotion selectable, saves correctly, and displays in the table row. Test record cleaned up.