### PR TITLE
feat: add POST /api/auth/refresh for silent mobile token renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Added
+
+- **`POST /api/auth/refresh`** — issues a fresh JWT for the current user, provided their existing token is still valid (`authenticateToken` re-checks `is_active` against the DB rather than trusting the token payload, so a deactivated user can't refresh even with an unexpired token). The new token reflects the user's *current* role/username from the DB, not whatever was in the original token — so a promoted/demoted user gets it right on refresh. Intended for mobile clients to silently renew their session before the token's natural expiry, rather than forcing a full re-login.
+
 ### 🔧 Code Quality
 
 - **CodeQL cleanup** — resolved all 12 open CodeQL alerts (all low-severity reliability/cleanliness findings, no vulnerabilities): removed 7 dead `const form = document.getElementById(...)` declarations left over in `saveX()` functions across appointments, prescriptions, patients, medications, doctors, institutions, and conditions pages; removed an unused `newTab` variable capturing `window.open()`'s return value in lab-reports.js; removed a `let overallStatus` variable in lab-reports.js that was assigned but never read (the actually-used `statusBadge` variable was untouched); removed an unused `Logger` variable in `logger.test.js` while preserving its `jest.resetModules()` side effect; removed an unused `path` import in `server.js`.

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -165,6 +165,35 @@ router.post('/login', async (req, res) => {
   }
 });
 
+// Issue a fresh token for the current user, provided their existing token
+// is still valid (enforced by authenticateToken, which also re-checks
+// is_active against the DB rather than trusting the token payload).
+// Intended for silent client-side renewal before the current token expires.
+router.post('/refresh', authenticateToken, async (req, res) => {
+  try {
+    const token = jwt.sign(
+      {
+        userId: req.user.id,
+        username: req.user.username,
+        role: req.user.role
+      },
+      JWT_SECRET,
+      { expiresIn: JWT_EXPIRES_IN }
+    );
+
+    res.json({
+      success: true,
+      data: { token }
+    });
+  } catch (error) {
+    logger.error('Token refresh failed', { error: error.message, stack: error.stack, userId: req.user.id });
+    res.status(500).json({
+      success: false,
+      error: 'Failed to refresh token'
+    });
+  }
+});
+
 // Get current user info
 router.get('/me', authenticateToken, async (req, res) => {
   try {

--- a/backend/tests/routes/auth.test.js
+++ b/backend/tests/routes/auth.test.js
@@ -210,6 +210,67 @@ describe('GET /api/auth/me', () => {
   });
 });
 
+// ─── POST /api/auth/refresh ────────────────────────────────────────────────
+
+describe('POST /api/auth/refresh', () => {
+  it('returns 401 when no Authorization header', async () => {
+    const res = await request(app).post('/api/auth/refresh');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when token is invalid', async () => {
+    const res = await request(app)
+      .post('/api/auth/refresh')
+      .set('Authorization', 'Bearer totally.invalid.token');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when the user backing a well-formed token is inactive', async () => {
+    const token = jwt.sign({ userId: 1, username: 'alice', role: 'user' }, JWT_SECRET);
+    db.query.mockResolvedValueOnce({
+      rows: [{ id: 1, username: 'alice', role: 'user', is_active: false, patient_id: null }],
+    });
+    const res = await request(app)
+      .post('/api/auth/refresh')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with a new token for a currently-valid token', async () => {
+    const token = jwt.sign({ userId: 1, username: 'alice', role: 'user' }, JWT_SECRET);
+    db.query.mockResolvedValueOnce({
+      rows: [{ id: 1, username: 'alice', role: 'user', is_active: true, patient_id: null }],
+    });
+    const res = await request(app)
+      .post('/api/auth/refresh')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.data.token).toBe('string');
+
+    const decoded = jwt.verify(res.body.data.token, JWT_SECRET);
+    expect(decoded.userId).toBe(1);
+    expect(decoded.username).toBe('alice');
+    expect(decoded.role).toBe('user');
+  });
+
+  it('issues a token even for a role/username different from the original payload (reflects current DB state)', async () => {
+    // Token was signed while the user was 'user', but they've since been
+    // promoted to 'admin' - refresh should reflect the current DB role,
+    // not whatever was baked into the original token payload.
+    const token = jwt.sign({ userId: 1, username: 'alice', role: 'user' }, JWT_SECRET);
+    db.query.mockResolvedValueOnce({
+      rows: [{ id: 1, username: 'alice', role: 'admin', is_active: true, patient_id: null }],
+    });
+    const res = await request(app)
+      .post('/api/auth/refresh')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    const decoded = jwt.verify(res.body.data.token, JWT_SECRET);
+    expect(decoded.role).toBe('admin');
+  });
+});
+
 // ─── PUT /api/auth/change-password ────────────────────────────────────────
 
 describe('PUT /api/auth/change-password', () => {


### PR DESCRIPTION
Mobile app has no refresh mechanism today: Auth.build() in the Flutter client checks JWT expiry on every app open and immediately force-logs-out if expired, with no attempt to renew first. Combined with JWT_EXPIRES_IN having a one-shot expiry and no rolling renewal, this is why the app logs users out after a few days regardless of usage.

router.post('/refresh', authenticateToken, ...) re-signs a token with a fresh expiry for the authenticated user. Protected by the existing authenticateToken middleware, which already re-verifies the user against the DB (is_active check) rather than trusting the token payload - so this endpoint can't be used to renew a token for a deactivated account, and correctly reflects the user's current role rather than stale claims from the original login.

Note: the originally proposed snippet used req.user.userId, but authenticateToken sets req.user = { id, username, role, patientId } - fixed to req.user.id.

Verified: live end-to-end (valid token -> new working token that authenticates against /me; no token -> 401; garbage token -> 403). Added 5 tests covering the auth boundary and the stale-payload-vs- current-DB-state behavior. Full suite 407/407.

Mobile-side changes (proactive refresh-on-open, reactive refresh-on-401) intentionally not made here - separate repo, holding for review first.