### PR TITLE
fix: restore backdrop blur on glass surfaces lost in production builds

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -70,8 +70,15 @@
   .glass {
     background: var(--color-glass);
     border: 1px solid var(--color-glass-border);
-    backdrop-filter: blur(22px);
-    -webkit-backdrop-filter: blur(22px);
+    /* Using Tailwind's own backdrop-blur utility here rather than hand-written
+       backdrop-filter/-webkit-backdrop-filter: Tailwind's CSS pipeline (Lightning
+       CSS under @tailwindcss/vite) was silently dropping the unprefixed
+       backdrop-filter declaration from this rule during the production build —
+       present in dev, gone once built — leaving glass surfaces fully see-through
+       in production. @apply lets Tailwind generate + prefix the property itself
+       instead of us writing both variants by hand and hoping the build doesn't
+       collapse them wrong. */
+    @apply backdrop-blur-[22px];
   }
 
   .glow-gradient {


### PR DESCRIPTION
The .glass utility (used by the sidebar, topbar, cards, and every dropdown/menu in the app) renders correctly in dev but the production build was silently dropping its backdrop-filter declaration entirely, leaving anything relying on it for readability - most visibly the user-profile dropdown, whose background is only 5.5% opaque white and depends entirely on the blur to be legible - fully see-through with the dashboard content showing straight through the menu.

Confirmed this wasn't a minifier issue (reproduced with cssMinify disabled too) - Tailwind's own CSS pipeline (Lightning CSS, used by @tailwindcss/vite) was collapsing the hand-written backdrop-filter / -webkit-backdrop-filter pair, keeping neither in the worst case seen on a live deployment and only the -webkit- one in a clean local build.

Fixed by using Tailwind's own backdrop-blur-[22px] utility via @apply instead of hand-rolling both vendor-prefixed properties - Tailwind generates and composes these itself via its own --tw-backdrop-* custom properties, which survive its build pipeline correctly since that's the exact case it's built to handle.

Verified end to end: built the actual production Docker image, confirmed the built CSS carries both properties this time, ran it against the real backend, and confirmed via computed styles and a screenshot that the dropdown now renders as a proper frosted panel instead of transparent.